### PR TITLE
Fix IPv6 issue on module.go

### DIFF
--- a/module.go
+++ b/module.go
@@ -36,7 +36,7 @@ func (m *module) ServeHTTP(w http.ResponseWriter, req *http.Request) (int, error
 		//restore original host:port format
 		leftMost := strings.Split(hVal, ",")[0]
 		if net.ParseIP(leftMost) != nil {
-			req.RemoteAddr = leftMost + ":" + port
+			req.RemoteAddr = net.JoinHostPort(leftMost, port)
 		}
 	}
 	return m.next.ServeHTTP(w, req)


### PR DESCRIPTION
Using net.JoinHostPort for proper RemoteAddr host:port concatenation when IPv6 comes to play

Additional information:
https://forum.caddyserver.com/t/ipv6-realip-and-ipfilter-middlewares-troubleshooting/568
