### PR TITLE
Need to account for whitespace

### DIFF
--- a/module.go
+++ b/module.go
@@ -2,10 +2,11 @@ package realip
 
 import (
 	"fmt"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
 	"net"
 	"net/http"
-	"strings"
+	"regexp"
+
+	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
 type module struct {
@@ -51,7 +52,7 @@ func (m *module) ServeHTTP(w http.ResponseWriter, req *http.Request) (int, error
 
 	if hVal := req.Header.Get(m.Header); hVal != "" {
 		//restore original host:port format
-		parts := strings.Split(hVal, ",")
+		parts := regexp.MustCompile(`,\s*`).Split(hVal, -1)
 		if m.MaxHops != -1 && len(parts) > m.MaxHops {
 			return 403, fmt.Errorf("Too many forward addresses")
 		}

--- a/module.go
+++ b/module.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"regexp"
+	"strings"
 
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
@@ -52,7 +52,10 @@ func (m *module) ServeHTTP(w http.ResponseWriter, req *http.Request) (int, error
 
 	if hVal := req.Header.Get(m.Header); hVal != "" {
 		//restore original host:port format
-		parts := regexp.MustCompile(`,\s*`).Split(hVal, -1)
+		parts := strings.Split(hVal, ",")
+		for i, part := range parts {
+			parts[i] = strings.TrimSpace(part)
+		}
 		if m.MaxHops != -1 && len(parts) > m.MaxHops {
 			return 403, fmt.Errorf("Too many forward addresses")
 		}


### PR DESCRIPTION
Currently the plugin splits on commas, but doesn't account for the possibility of whitespace, which is quite common in the `X-Forwarded-For` header. This results in trying to parse an IP address with leading whitespace, which then fails, despite the IP address being valid.